### PR TITLE
fix(desktop): run image translation on a CPU engine on Linux

### DIFF
--- a/desktopApp/src/main/kotlin/main.kt
+++ b/desktopApp/src/main/kotlin/main.kt
@@ -54,6 +54,7 @@ import dev.nucleusframework.window.macOSLargeCornerRadius
 import dev.nucleusframework.window.material.MaterialDecoratedWindow
 import dev.nucleusframework.window.windowDragArea
 import dev.nucleusframework.offlinetranslator.engine.runGpuWorker
+import dev.nucleusframework.offlinetranslator.platform.InstallDesktopFilePicker
 import io.github.vinceglb.filekit.FileKit
 
 private const val DESKTOP_DENSITY_SCALE = 0.75f
@@ -132,6 +133,7 @@ fun main(args: Array<String>) {
                             // Host-only: the meters read this machine via system-info.
                             LocalSystemMeters provides { modifier -> SystemMeters(modifier) },
                         ) {
+                            InstallDesktopFilePicker(windowScope.nucleusWindow)
                             App(
                                 // SideEffect: App reports the resolved theme during
                                 // composition, so the write has to land after it.

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -75,6 +75,8 @@ kotlin {
             implementation(libs.sqlDelight.driver.sqlite)
             implementation(libs.sqlite.jdbc)
             implementation(libs.nucleus.core.runtime)
+            implementation(libs.nucleus.application)
+            implementation(libs.nucleus.decorated.window.tao)
             implementation(libs.nucleus.system.color)
             implementation(libs.nucleus.system.info)
             implementation(libs.nucleus.native.http.ktor)

--- a/shared/src/androidMain/kotlin/dev/nucleusframework/offlinetranslator/platform/FileKitIo.android.kt
+++ b/shared/src/androidMain/kotlin/dev/nucleusframework/offlinetranslator/platform/FileKitIo.android.kt
@@ -1,0 +1,9 @@
+package dev.nucleusframework.offlinetranslator.platform
+
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.openFilePicker
+import io.github.vinceglb.filekit.readBytes
+
+internal actual suspend fun filekitPickImage(): ByteArray? =
+    FileKit.openFilePicker(FileKitType.Image)?.readBytes()

--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/platform/DropPayload.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/platform/DropPayload.kt
@@ -20,16 +20,37 @@ private val IMAGE_EXT = setOf("png", "jpg", "jpeg", "gif", "webp", "bmp")
 private val TEXT_EXT = setOf("txt", "md", "csv", "json", "log", "html", "htm", "xml")
 
 internal fun resolveDrop(clipboardText: String?, paths: List<String>): DropChoice {
-    val image = paths.firstOrNull { it.fileExtension() in IMAGE_EXT }
+    val allPaths = paths + pathsFromText(clipboardText)
+    val image = allPaths.firstOrNull { it.fileExtension() in IMAGE_EXT }
     if (image != null) return DropChoice.ImagePath(image)
-    val textFile = paths.firstOrNull { it.fileExtension() in TEXT_EXT }
+    val textFile = allPaths.firstOrNull { it.fileExtension() in TEXT_EXT }
     if (textFile != null) return DropChoice.TextPath(textFile)
     // File list is the payload. The string flavor is usually just the path —
     // don't paste that into the source field.
-    if (paths.isNotEmpty()) return DropChoice.Unsupported
+    if (allPaths.isNotEmpty()) return DropChoice.Unsupported
     val clip = clipboardText?.trim().orEmpty()
     if (clip.isNotEmpty()) return DropChoice.Clipboard(clip)
     return DropChoice.Empty
+}
+
+/** File URIs and absolute paths carried by `text/uri-list` / string flavor on Linux. */
+internal fun pathsFromText(text: String?): List<String> {
+    if (text.isNullOrBlank()) return emptyList()
+    return text.lineSequence()
+        .map { it.trim() }
+        .filter { it.isNotEmpty() && !it.startsWith("#") }
+        .mapNotNull(::pathFromDropLine)
+        .toList()
+}
+
+private fun pathFromDropLine(line: String): String? {
+    val uri = line.trim()
+    if (uri.startsWith("file:", ignoreCase = true)) {
+        return runCatching { java.net.URI(uri).path }.getOrNull()?.takeIf { it.isNotEmpty() }
+    }
+    if (uri.startsWith("/")) return uri
+    if (uri.length >= 3 && uri[1] == ':' && uri[0].isLetter()) return uri
+    return null
 }
 
 internal fun String.fileExtension(): String = substringAfterLast('.', missingDelimiterValue = "").lowercase()

--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/platform/FileKitIo.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/platform/FileKitIo.kt
@@ -5,14 +5,11 @@ import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.cacheDir
 import io.github.vinceglb.filekit.createDirectories
 import io.github.vinceglb.filekit.databasesDir
-import io.github.vinceglb.filekit.dialogs.FileKitType
-import io.github.vinceglb.filekit.dialogs.openFilePicker
 import io.github.vinceglb.filekit.exists
 import io.github.vinceglb.filekit.filesDir
 import io.github.vinceglb.filekit.isRegularFile
 import io.github.vinceglb.filekit.parent
 import io.github.vinceglb.filekit.path
-import io.github.vinceglb.filekit.readBytes
 import io.github.vinceglb.filekit.sink
 import io.github.vinceglb.filekit.size
 import io.github.vinceglb.filekit.source
@@ -25,7 +22,7 @@ import kotlinx.io.writeString
 internal fun filekitFilesDir(): String = FileKit.filesDir.path
 
 /** `null` when the user cancels the picker. */
-internal suspend fun filekitPickImage(): ByteArray? = FileKit.openFilePicker(FileKitType.Image)?.readBytes()
+internal expect suspend fun filekitPickImage(): ByteArray?
 
 internal fun filekitCacheDir(): String = FileKit.cacheDir.path
 

--- a/shared/src/commonTest/kotlin/dev/nucleusframework/offlinetranslator/DropPayloadTest.kt
+++ b/shared/src/commonTest/kotlin/dev/nucleusframework/offlinetranslator/DropPayloadTest.kt
@@ -36,6 +36,27 @@ class DropPayloadTest {
     }
 
     @Test
+    fun linuxUriListIsAnImageFile() {
+        val choice = resolveDrop("file:///tmp/shot.png\r\n", emptyList())
+        assertIs<DropChoice.ImagePath>(choice)
+        assertEquals("/tmp/shot.png", choice.path)
+    }
+
+    @Test
+    fun linuxUriListDoesNotPasteThePath() {
+        val choice = resolveDrop("file:///tmp/notes.md", emptyList())
+        assertIs<DropChoice.TextPath>(choice)
+        assertEquals("/tmp/notes.md", choice.path)
+    }
+
+    @Test
+    fun fileUriDecodesSpaces() {
+        val choice = resolveDrop("file:///tmp/my%20shot.PNG", emptyList())
+        assertIs<DropChoice.ImagePath>(choice)
+        assertEquals("/tmp/my shot.PNG", choice.path)
+    }
+
+    @Test
     fun emptyWhenNothingReadable() {
         assertEquals(DropChoice.Empty, resolveDrop("   ", emptyList()))
         assertEquals(DropChoice.Empty, resolveDrop(null, emptyList()))

--- a/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/engine/NativeLlm.jvm.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/engine/NativeLlm.jvm.kt
@@ -85,7 +85,8 @@ internal actual class NativeLlm actual constructor() {
         onPartial: (String) -> Unit,
     ): String {
         val child = worker
-        if (child != null && (audioWav == null || audioWav.isEmpty()) && (image == null || image.isEmpty())) {
+        val media = hasMultimodalPayload(audioWav, image)
+        if (child != null && !media) {
             try {
                 return child.generate(systemInstruction, userMessage, onPartial)
             } catch (e: kotlinx.coroutines.CancellationException) {
@@ -96,6 +97,9 @@ internal actual class NativeLlm actual constructor() {
                 ensureCpuEngine()
             }
         }
+        // GPU lives in the child JVM (NVIDIA SIGILL in-process). Vision / audio
+        // stay in this process on a CPU engine — the worker protocol is text-only.
+        if (engine == null) ensureCpuEngine()
         return generateInProcess(systemInstruction, userMessage, audioWav, image, onPartial)
     }
 
@@ -245,6 +249,9 @@ internal fun linuxGpuCompanionLibs(): List<String> = listOf(
 internal fun inGpuWorkerProcess(): Boolean =
     System.getProperty("edgetranslator.gpu.worker") == "1" ||
         System.getenv("EDGE_TRANSLATOR_GPU_WORKER") == "1"
+
+internal fun hasMultimodalPayload(audioWav: ByteArray?, image: ByteArray?): Boolean =
+    (audioWav != null && audioWav.isNotEmpty()) || (image != null && image.isNotEmpty())
 
 private fun appResourcesDir(): java.io.File? =
     System.getProperty("compose.application.resources.dir")?.let { java.io.File(it) }

--- a/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/platform/DropPayload.jvm.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/platform/DropPayload.jvm.kt
@@ -9,20 +9,22 @@ import java.io.File
 // Same AWT transfer path as Nucleus tao-demo / compose-demo:
 // DragAndDropEvent.awtTransferable + javaFileListFlavor / stringFlavor.
 
+private val URI_LIST_FLAVOR = DataFlavor("text/uri-list;class=java.lang.String")
+
 @OptIn(ExperimentalComposeUiApi::class)
 internal actual fun readDropPayload(event: DragAndDropEvent): DropPayload {
     val transferable = runCatching { event.awtTransferable }.getOrNull() ?: return DropPayload()
-    val text = if (transferable.isDataFlavorSupported(DataFlavor.stringFlavor)) {
-        runCatching { transferable.getTransferData(DataFlavor.stringFlavor) as? String }.getOrNull()
+    val text = flavorString(transferable, DataFlavor.stringFlavor)
+    val uriList = flavorString(transferable, URI_LIST_FLAVOR)
+    val files = if (transferable.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+        @Suppress("UNCHECKED_CAST")
+        runCatching { transferable.getTransferData(DataFlavor.javaFileListFlavor) as? List<File> }.getOrNull()
     } else {
         null
     }
-    val paths = if (transferable.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
-        @Suppress("UNCHECKED_CAST")
-        val files = runCatching { transferable.getTransferData(DataFlavor.javaFileListFlavor) as? List<File> }.getOrNull()
-        files.orEmpty().map { it.absolutePath }
-    } else {
-        emptyList()
+    val paths = buildList {
+        files.orEmpty().forEach { add(it.absolutePath) }
+        addAll(pathsFromText(uriList))
     }
     return when (val choice = resolveDrop(text, paths)) {
         is DropChoice.ImagePath -> {
@@ -37,4 +39,12 @@ internal actual fun readDropPayload(event: DragAndDropEvent): DropPayload {
         DropChoice.Unsupported -> DropPayload(unsupported = true)
         DropChoice.Empty -> DropPayload()
     }
+}
+
+private fun flavorString(
+    transferable: java.awt.datatransfer.Transferable,
+    flavor: DataFlavor,
+): String? {
+    if (!transferable.isDataFlavorSupported(flavor)) return null
+    return runCatching { transferable.getTransferData(flavor) as? String }.getOrNull()
 }

--- a/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/platform/FileKitIo.jvm.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/platform/FileKitIo.jvm.kt
@@ -1,0 +1,75 @@
+package dev.nucleusframework.offlinetranslator.platform
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import dev.nucleusframework.application.NucleusWindow
+import dev.nucleusframework.window.tao.XdgPortalParent
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.dialogs.FileKitDialogParent
+import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.openFilePicker
+import io.github.vinceglb.filekit.readBytes
+
+/**
+ * Tao is not an AWT window. On Linux the XDG portal file chooser stays blank
+ * or never maps unless it is parented to the live X11 XID / Wayland export.
+ */
+internal object FilePickerParent {
+    @Volatile
+    var window: NucleusWindow? = null
+}
+
+@Composable
+fun InstallDesktopFilePicker(window: NucleusWindow) {
+    DisposableEffect(window) {
+        FilePickerParent.window = window
+        onDispose {
+            if (FilePickerParent.window === window) FilePickerParent.window = null
+        }
+    }
+}
+
+internal actual suspend fun filekitPickImage(): ByteArray? {
+    val owned = FilePickerParent.window?.fileKitDialog()
+        ?: return FileKit.openFilePicker(type = FileKitType.Image)?.readBytes()
+    return owned.use { dialog ->
+        FileKit.openFilePicker(
+            type = FileKitType.Image,
+            dialogSettings = dialog.settings,
+        )?.readBytes()
+    }
+}
+
+private class OwnedFileKitDialog(
+    val settings: FileKitDialogSettings,
+    private val closer: AutoCloseable?,
+) : AutoCloseable {
+    override fun close() {
+        closer?.close()
+    }
+}
+
+private fun NucleusWindow.fileKitDialog(): OwnedFileKitDialog {
+    val tao = unsafe.taoWindow
+    if (tao != null) {
+        when (val parent = tao.xdgPortalParent()) {
+            is XdgPortalParent.X11 -> return OwnedFileKitDialog(
+                FileKitDialogSettings(parent = FileKitDialogParent.x11(parent.xid)),
+                closer = null,
+            )
+            is XdgPortalParent.Wayland -> return OwnedFileKitDialog(
+                FileKitDialogSettings(parent = FileKitDialogParent.wayland(parent.handle)),
+                closer = parent,
+            )
+            null -> Unit
+        }
+    }
+    unsafe.awtWindow?.let { awt ->
+        return OwnedFileKitDialog(
+            FileKitDialogSettings(parent = FileKitDialogParent.awt(awt)),
+            closer = null,
+        )
+    }
+    return OwnedFileKitDialog(FileKitDialogSettings(), closer = null)
+}

--- a/shared/src/jvmTest/kotlin/dev/nucleusframework/offlinetranslator/LinuxGpuPolicyTest.kt
+++ b/shared/src/jvmTest/kotlin/dev/nucleusframework/offlinetranslator/LinuxGpuPolicyTest.kt
@@ -4,6 +4,7 @@ import dev.nucleusframework.offlinetranslator.engine.WorkerEvent
 import dev.nucleusframework.offlinetranslator.engine.decodeWorkerField
 import dev.nucleusframework.offlinetranslator.engine.encodeWorkerField
 import dev.nucleusframework.offlinetranslator.engine.LinuxGpuWorkerProcess
+import dev.nucleusframework.offlinetranslator.engine.hasMultimodalPayload
 import dev.nucleusframework.offlinetranslator.engine.linuxGpuCompanionLibs
 import dev.nucleusframework.offlinetranslator.engine.linuxGpuTeardownUnsafe
 import dev.nucleusframework.offlinetranslator.engine.parseWorkerLine
@@ -43,6 +44,14 @@ class LinuxGpuPolicyTest {
             assertTrue("dev.nucleusframework.offlinetranslator.engine.LinuxGpuWorkerKt" in args)
             assertTrue("-cp" in args)
         }
+    }
+
+    @Test
+    fun imageAndAudioSkipTheGpuWorker() {
+        assertFalse(hasMultimodalPayload(null, null))
+        assertFalse(hasMultimodalPayload(byteArrayOf(), byteArrayOf()))
+        assertTrue(hasMultimodalPayload(byteArrayOf(1), null))
+        assertTrue(hasMultimodalPayload(null, byteArrayOf(1)))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- After picking or dropping an image on NVIDIA Linux, generate ran in the UI process with no engine loaded — the GPU worker is text-only. Open a CPU engine in-process for vision and audio.
- Parent the XDG file dialog to the Tao window and accept `file://` / `text/uri-list` drops so Linux file managers are not pasted as source text.

## Test plan
- [x] `./gradlew :shared:jvmTest`
- [x] Pick an image on Linux — translation starts after selection
- [x] Drop an image on the source panel
- [ ] Confirm text translation still uses the GPU worker