### PR TITLE
fix: adopt LiteRT-LM registry models already on disk

### DIFF
--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/app/AppViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/app/AppViewModel.kt
@@ -334,6 +334,10 @@ class AppViewModel(
         data = coerceModelForRam(data, ram)
         LlmRuntime.preference = data.settings.backend
         val catalog = GemmaModels.of(data.settings.selectedModel)
+        if (modelOnDisk(catalog) && (!data.model.installed || data.model.id != catalog.id)) {
+            data = data.copy(model = catalog.toInfo(clock()))
+            store.save(data.copy(history = emptyList()))
+        }
         val download = if (modelOnDisk(catalog)) {
             DownloadState(phase = DownloadPhase.Done, bytesDownloaded = catalog.bytes, totalBytes = catalog.bytes)
         } else {
@@ -386,9 +390,16 @@ class AppViewModel(
 
         AppIntent.InstallBack -> s.gotoInstall(s.installStep().previous())
 
-        AppIntent.OpenApp -> s.copy(
-            data = s.data.copy(installed = true, installStep = InstallStep.Download.name),
-        )
+        AppIntent.OpenApp -> {
+            val catalog = GemmaModels.of(s.data.settings.selectedModel)
+            s.copy(
+                data = s.data.copy(
+                    installed = true,
+                    installStep = InstallStep.Download.name,
+                    model = if (modelOnDisk(catalog)) catalog.toInfo(clock()) else s.data.model,
+                ),
+            )
+        }
 
         is AppIntent.GoToStep -> {
             val next = s.gotoInstall(intent.step)
@@ -632,7 +643,18 @@ class AppViewModel(
         val onDisk = modelOnDisk(catalog)
         if (!onDisk && s.data.installed) return s
         if (s.data.settings.selectedModel == id && (onDisk || s.download.running || !s.data.installed)) {
-            return s
+            return if (onDisk && (!s.data.model.installed || s.data.model.id != id)) {
+                s.copy(
+                    data = s.data.copy(model = catalog.toInfo(clock())),
+                    download = DownloadState(
+                        phase = DownloadPhase.Done,
+                        bytesDownloaded = catalog.bytes,
+                        totalBytes = catalog.bytes,
+                    ),
+                )
+            } else {
+                s
+            }
         }
         val next = s.updateSettings { it.copy(selectedModel = id) }
         return if (onDisk) {

--- a/shared/src/commonTest/kotlin/dev/nucleusframework/offlinetranslator/AppViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/dev/nucleusframework/offlinetranslator/AppViewModelTest.kt
@@ -1288,6 +1288,56 @@ class AppViewModelTest {
         assertTrue(removedModels.isEmpty())
         assertFalse(vm.state.value.data.installed)
     }
+
+    @Test
+    fun restoreAdoptsModelAlreadyOnDisk() {
+        val store = MemoryStore(
+            seedData().copy(
+                installed = true,
+                settings = seedData().settings.copy(selectedModel = LlmModel.Precise),
+                model = seedData().model.copy(id = LlmModel.Precise, installed = false, path = ""),
+            ),
+        )
+        val vm = vm(store = store, now = 42L, modelOnDisk = { it.id == LlmModel.Precise })
+        val model = vm.state.value.data.model
+        assertTrue(model.installed)
+        assertEquals(LlmModel.Precise, model.id)
+        assertEquals(42L, model.installedAt)
+        assertTrue(model.path.endsWith("model.litertlm"))
+        assertTrue(vm.state.value.download.done)
+        assertTrue(store.load().model.installed)
+    }
+
+    @Test
+    fun openAppAdoptsModelAlreadyOnDisk() {
+        val vm = vm(
+            store = MemoryStore(seedData().copy(settings = seedData().settings.copy(selectedModel = LlmModel.Precise))),
+            modelOnDisk = { it.id == LlmModel.Precise },
+        )
+        assertTrue(vm.state.value.data.model.installed)
+        vm.onIntent(AppIntent.OpenApp)
+        assertTrue(vm.state.value.data.installed)
+        assertTrue(vm.state.value.data.model.installed)
+        assertEquals(LlmModel.Precise, vm.state.value.data.model.id)
+    }
+
+    @Test
+    fun selectAlreadyChosenOnDiskModelMarksInstalled() {
+        val vm = vm(
+            store = MemoryStore(
+                seedData().copy(
+                    installed = true,
+                    settings = seedData().settings.copy(selectedModel = LlmModel.Precise),
+                    model = seedData().model.copy(id = LlmModel.Precise, installed = false, path = ""),
+                ),
+            ),
+            modelOnDisk = { it.id == LlmModel.Precise },
+        )
+        assertTrue(vm.state.value.data.model.installed)
+        vm.onIntent(AppIntent.SelectModel(LlmModel.Precise))
+        assertTrue(vm.state.value.data.model.installed)
+        assertEquals(LlmModel.Precise, vm.state.value.data.model.id)
+    }
 }
 
 private fun installedModel(keepAlive: LlmKeepAlive = LlmKeepAlive.OnDemand) = seedData().copy(


### PR DESCRIPTION
## Summary
- Treat Gemma weights already present in the LiteRT-LM CLI registry as installed, not just downloaded
- Adopt on-disk models on restore, at the end of onboarding, and when re-selecting the current model
- Fixes translation showing "Install a model" after a local move/rename into `~/.litert-lm/models`

## Test plan
- [x] `:shared:jvmTest` for adopt-on-disk / OpenApp / select / install / reset cases
- [ ] Launch desktop app with Precise already at `~/.litert-lm/models/gemma4-e4b/model.litertlm` and confirm translate works without a re-download
- [ ] Settings still shows the model as installed and selected