### PR TITLE
feat(desktop): use Nucleus native SSL for auto-update

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,6 +79,7 @@ nucleus-decorated-window-material3 = { module = "dev.nucleusframework:nucleus.de
 nucleus-core-runtime = { module = "dev.nucleusframework:nucleus.core-runtime", version.ref = "nucleus" }
 nucleus-system-color = { module = "dev.nucleusframework:nucleus.system-color", version.ref = "nucleus" }
 nucleus-system-info = { module = "dev.nucleusframework:nucleus.system-info", version.ref = "nucleus" }
+nucleus-native-http = { module = "dev.nucleusframework:nucleus.native-http", version.ref = "nucleus" }
 nucleus-native-http-ktor = { module = "dev.nucleusframework:nucleus.native-http-ktor", version.ref = "nucleus" }
 nucleus-updater-runtime = { module = "dev.nucleusframework:nucleus.updater-runtime", version.ref = "nucleus" }
 litertlm-android = { module = "com.google.ai.edge.litertlm:litertlm-android", version.ref = "litertlm" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -79,6 +79,7 @@ kotlin {
             implementation(libs.nucleus.decorated.window.tao)
             implementation(libs.nucleus.system.color)
             implementation(libs.nucleus.system.info)
+            implementation(libs.nucleus.native.http)
             implementation(libs.nucleus.native.http.ktor)
             implementation(libs.nucleus.updater.runtime)
             implementation(libs.litertlm.jvm)

--- a/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/main/DesktopUpdate.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/main/DesktopUpdate.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.nucleusframework.nativehttp.NativeHttpClient
 import dev.nucleusframework.offlinetranslator.ui.FilledPill
 import dev.nucleusframework.offlinetranslator.ui.OutlinedPill
 import dev.nucleusframework.updater.NucleusUpdater
@@ -70,6 +71,7 @@ fun rememberDesktopUpdate(): DesktopUpdate {
     val updater = remember {
         NucleusUpdater {
             provider = GitHubProvider(owner = UPDATE_OWNER, repo = UPDATE_REPO)
+            httpClient = NativeHttpClient.create()
         }
     }
     var file by remember { mutableStateOf<File?>(null) }


### PR DESCRIPTION
## Summary
- Point `NucleusUpdater` at `NativeHttpClient.create()` so update checks and downloads use the OS trust store (enterprise / user-installed CAs), matching Nucleus’s documented updater SSL path.
- Add `nucleus.native-http` to the version catalog and `jvmMain` dependencies.

## Test plan
- [x] `:shared:compileKotlinJvm` succeeds
- [ ] On a machine with a custom/enterprise CA, launch a packaged desktop build and confirm `checkForUpdates` reaches GitHub without TLS errors
- [ ] On a stock machine, confirm update check still works against `api.github.com` / GitHub release assets