### PR TITLE
feat(android): try NPU first when loading the LLM

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -13,6 +13,11 @@
         android:theme="@android:style/Theme.Material.NoActionBar">
         <uses-native-library android:name="libvndksupport.so" android:required="false" />
         <uses-native-library android:name="libOpenCL.so" android:required="false" />
+        <uses-native-library android:name="libcdsprpc.so" android:required="false" />
+        <uses-native-library android:name="libedgetpu_litert.so" android:required="false" />
+        <uses-native-library android:name="libedgetpu_util.so" android:required="false" />
+        <uses-native-library android:name="libedgetpu_client.google.so" android:required="false" />
+        <uses-native-library android:name="libedgetpu_tachyon.google.so" android:required="false" />
         <activity
             android:name=".AppActivity"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"

--- a/shared/src/androidMain/kotlin/dev/nucleusframework/offlinetranslator/engine/NativeLlm.android.kt
+++ b/shared/src/androidMain/kotlin/dev/nucleusframework/offlinetranslator/engine/NativeLlm.android.kt
@@ -10,24 +10,29 @@ import com.google.ai.edge.litertlm.SamplerConfig
 // litertlm-android 0.14.0 has no ThinkingConfig / maxOutputToken (added in 0.15+).
 // import com.google.ai.edge.litertlm.ThinkingConfig
 import dev.nucleusframework.offlinetranslator.domain.LlmBackend
+import dev.nucleusframework.offlinetranslator.platform.androidContext
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.HttpTimeout
 
 internal actual class NativeLlm actual constructor() {
     private var engine: Engine? = null
+    private var npuSampler: Boolean = false
 
     actual fun load(modelPath: String, cacheDir: String, threads: Int, backend: LlmBackend): LlmAccelerator {
         close()
-        val pick = pickBackend(backend, LlmRuntime.gpuAvailable.value) {
-            val gpu = runCatching { openEngine(modelPath, cacheSubdir(cacheDir, "gpu"), Backend.GPU()) }.getOrNull()
-            if (gpu != null) {
-                engine = gpu
-                true
-            } else {
-                false
-            }
-        }
+        val nativeLibDir = androidContext().applicationInfo.nativeLibraryDir
+        val pick = pickBackend(
+            preference = backend,
+            gpuKnown = LlmRuntime.gpuAvailable.value,
+            npuKnown = LlmRuntime.npuAvailable.value,
+            npuWorks = {
+                tryOpen(modelPath, cacheSubdir(cacheDir, "npu"), Backend.NPU(nativeLibraryDir = nativeLibDir))
+            },
+            gpuWorks = {
+                tryOpen(modelPath, cacheSubdir(cacheDir, "gpu"), Backend.GPU())
+            },
+        )
         if (engine == null) {
             engine = openEngine(
                 modelPath,
@@ -35,8 +40,19 @@ internal actual class NativeLlm actual constructor() {
                 Backend.CPU(threadCount = threads.takeIf { it > 0 }),
             )
         }
+        npuSampler = pick.accelerator == LlmAccelerator.Npu
         pick.gpuAvailable?.let(LlmRuntime::reportGpuAvailable)
+        pick.npuAvailable?.let(LlmRuntime::reportNpuAvailable)
         return pick.accelerator
+    }
+
+    private fun tryOpen(modelPath: String, cacheDir: String, backend: Backend): Boolean {
+        val opened = runCatching { openEngine(modelPath, cacheDir, backend) }.getOrNull()
+        if (opened != null) {
+            engine = opened
+            return true
+        }
+        return false
     }
 
     actual suspend fun generate(
@@ -50,7 +66,8 @@ internal actual class NativeLlm actual constructor() {
         e.createConversation(
             ConversationConfig(
                 systemInstruction = Contents.of(systemInstruction),
-                samplerConfig = SamplerConfig(topK = 1, topP = 1.0, temperature = 0.2),
+                // NPU rejects custom sampler configs (see Google AI Edge Gallery).
+                samplerConfig = if (npuSampler) null else SamplerConfig(topK = 1, topP = 1.0, temperature = 0.2),
                 // 0.14.0 ConversationConfig: thinkingConfig / maxOutputToken do not exist yet.
                 // thinkingConfig = ThinkingConfig(enableThinking = false),
                 channels = emptyList(),
@@ -84,6 +101,7 @@ internal actual class NativeLlm actual constructor() {
         } catch (_: Exception) {
         }
         engine = null
+        npuSampler = false
     }
 }
 

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -15,6 +15,7 @@
     <string name="about_version">الإصدار</string>
     <string name="offline">دون اتصال</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">تلقائي</string>
     <string name="nav_backend">الخلفية: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-bn/strings.xml
+++ b/shared/src/commonMain/composeResources/values-bn/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">সংস্করণ</string>
     <string name="offline">অফলাইন</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">স্বয়ংক্রিয়</string>
     <string name="nav_backend">ব্যাকএন্ড: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-cs/strings.xml
+++ b/shared/src/commonMain/composeResources/values-cs/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Verze</string>
     <string name="offline">Offline</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Backend: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-da/strings.xml
+++ b/shared/src/commonMain/composeResources/values-da/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Version</string>
     <string name="offline">Offline</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Backend: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -15,6 +15,7 @@
     <string name="about_version">Version</string>
     <string name="offline">Offline</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Backend: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-el/strings.xml
+++ b/shared/src/commonMain/composeResources/values-el/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Έκδοση</string>
     <string name="offline">Εκτός σύνδεσης</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Αυτόματα</string>
     <string name="nav_backend">Υπόβαθρο: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -15,6 +15,7 @@
     <string name="about_version">Versión</string>
     <string name="offline">Sin conexión</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Backend: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-fa/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fa/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">نسخه</string>
     <string name="offline">آفلاین</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">خودکار</string>
     <string name="nav_backend">پشتیبان: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-fi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fi/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Versio</string>
     <string name="offline">Offline</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Automaattinen</string>
     <string name="nav_backend">Tausta: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-fil/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fil/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Bersyon</string>
     <string name="offline">Offline</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Backend: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -15,6 +15,7 @@
     <string name="about_version">Version</string>
     <string name="offline">Hors-ligne</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Backend : %1$s</string>

--- a/shared/src/commonMain/composeResources/values-he/strings.xml
+++ b/shared/src/commonMain/composeResources/values-he/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">גרסה</string>
     <string name="offline">לא מקוון</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">אוטומטי</string>
     <string name="nav_backend">מנוע: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">संस्करण</string>
     <string name="offline">ऑफ़लाइन</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">स्वतः</string>
     <string name="nav_backend">बैकएंड: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-hr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hr/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Verzija</string>
     <string name="offline">Izvan mreže</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Pozadina: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-hu/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hu/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Verzió</string>
     <string name="offline">Offline</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Automatikus</string>
     <string name="nav_backend">Háttér: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-id/strings.xml
+++ b/shared/src/commonMain/composeResources/values-id/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Versi</string>
     <string name="offline">Luring</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Otomatis</string>
     <string name="nav_backend">Backend: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -15,6 +15,7 @@
     <string name="about_version">Versione</string>
     <string name="offline">Offline</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Backend: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -15,6 +15,7 @@
     <string name="about_version">バージョン</string>
     <string name="offline">オフライン</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">自動</string>
     <string name="nav_backend">バックエンド: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-ko/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ko/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">버전</string>
     <string name="offline">오프라인</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">자동</string>
     <string name="nav_backend">백엔드: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-mi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-mi/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Putanga</string>
     <string name="offline">Tuimotu</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Aunoa</string>
     <string name="nav_backend">Tuarā: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -15,6 +15,7 @@
     <string name="about_version">Versie</string>
     <string name="offline">Offline</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Backend: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-no/strings.xml
+++ b/shared/src/commonMain/composeResources/values-no/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Versjon</string>
     <string name="offline">Frakoblet</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Bakende: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-pl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pl/strings.xml
@@ -15,6 +15,7 @@
     <string name="about_version">Wersja</string>
     <string name="offline">Offline</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Backend: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -15,6 +15,7 @@
     <string name="about_version">Versão</string>
     <string name="offline">Offline</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Backend: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-ro/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ro/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Versiune</string>
     <string name="offline">Offline</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Backend: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -15,6 +15,7 @@
     <string name="about_version">Версия</string>
     <string name="offline">Офлайн</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Авто</string>
     <string name="nav_backend">Бэкенд: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-sv/strings.xml
+++ b/shared/src/commonMain/composeResources/values-sv/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Version</string>
     <string name="offline">Offline</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Backend: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-sw/strings.xml
+++ b/shared/src/commonMain/composeResources/values-sw/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Toleo</string>
     <string name="offline">Nje ya mtandao</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Otomatiki</string>
     <string name="nav_backend">Nyuma: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-te/strings.xml
+++ b/shared/src/commonMain/composeResources/values-te/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">వెర్షన్</string>
     <string name="offline">ఆఫ్‌లైన్</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">స్వయంచాలకం</string>
     <string name="nav_backend">బ్యాకెండ్: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-th/strings.xml
+++ b/shared/src/commonMain/composeResources/values-th/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">เวอร์ชัน</string>
     <string name="offline">ออฟไลน์</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">อัตโนมัติ</string>
     <string name="nav_backend">แบ็กเอนด์: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-tr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tr/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Sürüm</string>
     <string name="offline">Çevrimdışı</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Otomatik</string>
     <string name="nav_backend">Arka uç: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Версія</string>
     <string name="offline">Офлайн</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Авто</string>
     <string name="nav_backend">Бекенд: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-vi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-vi/strings.xml
@@ -14,6 +14,7 @@
     <string name="about_version">Phiên bản</string>
     <string name="offline">Ngoại tuyến</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Tự động</string>
     <string name="nav_backend">Phần phụ trợ: %1$s</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -15,6 +15,7 @@
     <string name="about_version">版本</string>
     <string name="offline">离线</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">自动</string>
     <string name="nav_backend">后端：%1$s</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="about_version">Version</string>
     <string name="offline">Offline</string>
     <string name="engine_gpu">GPU</string>
+    <string name="engine_npu">NPU</string>
     <string name="engine_cpu">CPU</string>
     <string name="engine_auto">Auto</string>
     <string name="nav_backend">Backend: %1$s</string>

--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/domain/Models.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/domain/Models.kt
@@ -55,7 +55,7 @@ private val COMMA_DECIMAL = setOf(
 
 enum class ThemeMode { System, Light, Dark }
 
-enum class LlmBackend { Auto, Gpu, Cpu }
+enum class LlmBackend { Auto, Npu, Gpu, Cpu }
 
 /** When the LLM stays in RAM. OnDemand loads on first use and unloads after idle. */
 enum class LlmKeepAlive { OnDemand, AlwaysOn }

--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/engine/LlmAccelerator.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/engine/LlmAccelerator.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-enum class LlmAccelerator { None, Cpu, Gpu }
+enum class LlmAccelerator { None, Cpu, Gpu, Npu }
 
 object LlmRuntime {
     @Volatile
@@ -17,6 +17,9 @@ object LlmRuntime {
     private val _gpuAvailable = MutableStateFlow<Boolean?>(null)
     val gpuAvailable: StateFlow<Boolean?> = _gpuAvailable.asStateFlow()
 
+    private val _npuAvailable = MutableStateFlow<Boolean?>(null)
+    val npuAvailable: StateFlow<Boolean?> = _npuAvailable.asStateFlow()
+
     internal fun report(value: LlmAccelerator) {
         _accelerator.value = value
     }
@@ -24,18 +27,36 @@ object LlmRuntime {
     internal fun reportGpuAvailable(available: Boolean) {
         _gpuAvailable.value = available
     }
+
+    internal fun reportNpuAvailable(available: Boolean) {
+        _npuAvailable.value = available
+    }
 }
 
-internal data class BackendPick(val accelerator: LlmAccelerator, val gpuAvailable: Boolean?)
+internal data class BackendPick(
+    val accelerator: LlmAccelerator,
+    val gpuAvailable: Boolean?,
+    val npuAvailable: Boolean? = null,
+)
 
 internal fun pickBackend(
     preference: LlmBackend,
     gpuKnown: Boolean?,
+    npuKnown: Boolean? = null,
+    npuWorks: () -> Boolean = { false },
     gpuWorks: () -> Boolean,
 ): BackendPick {
-    if (preference == LlmBackend.Cpu) return BackendPick(LlmAccelerator.Cpu, gpuKnown)
-    if (gpuKnown != false && gpuWorks()) return BackendPick(LlmAccelerator.Gpu, true)
-    return BackendPick(LlmAccelerator.Cpu, false)
+    if (preference == LlmBackend.Cpu) return BackendPick(LlmAccelerator.Cpu, gpuKnown, npuKnown)
+
+    val tryNpu = preference == LlmBackend.Auto || preference == LlmBackend.Npu
+    var npuAvailable = npuKnown
+    if (tryNpu && npuKnown != false) {
+        if (npuWorks()) return BackendPick(LlmAccelerator.Npu, gpuKnown, true)
+        npuAvailable = false
+    }
+
+    if (gpuKnown != false && gpuWorks()) return BackendPick(LlmAccelerator.Gpu, true, npuAvailable)
+    return BackendPick(LlmAccelerator.Cpu, false, npuAvailable)
 }
 
 /** NVIDIA WebGPU SIGILL after a GPU turn. ARM without NVIDIA stays in-process. */

--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/main/LlmAcceleratorBadge.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/main/LlmAcceleratorBadge.kt
@@ -16,21 +16,24 @@ import offlinetranslator.shared.generated.resources.em_dash
 import offlinetranslator.shared.generated.resources.engine_auto
 import offlinetranslator.shared.generated.resources.engine_cpu
 import offlinetranslator.shared.generated.resources.engine_gpu
+import offlinetranslator.shared.generated.resources.engine_npu
 import org.jetbrains.compose.resources.stringResource
 
-/** The backend chosen in Settings: Auto, GPU, or CPU. */
+/** The backend chosen in Settings: Auto, NPU, GPU, or CPU. */
 @Composable
 fun backendLabel(backend: LlmBackend): String = when (backend) {
     LlmBackend.Auto -> stringResource(Res.string.engine_auto)
+    LlmBackend.Npu -> stringResource(Res.string.engine_npu)
     LlmBackend.Gpu -> stringResource(Res.string.engine_gpu)
     LlmBackend.Cpu -> stringResource(Res.string.engine_cpu)
 }
 
-/** The backend the LLM is actually running on: GPU, CPU, or not loaded yet. */
+/** The backend the LLM is actually running on: NPU, GPU, CPU, or not loaded yet. */
 @Composable
 fun acceleratorLabel(): String {
     val accelerator by LlmRuntime.accelerator.collectAsState()
     return when (accelerator) {
+        LlmAccelerator.Npu -> stringResource(Res.string.engine_npu)
         LlmAccelerator.Gpu -> stringResource(Res.string.engine_gpu)
         LlmAccelerator.Cpu -> stringResource(Res.string.engine_cpu)
         LlmAccelerator.None -> stringResource(Res.string.em_dash)

--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/main/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/main/SettingsScreen.kt
@@ -60,6 +60,7 @@ import dev.nucleusframework.offlinetranslator.engine.CatalogModel
 import dev.nucleusframework.offlinetranslator.engine.GemmaModels
 import dev.nucleusframework.offlinetranslator.engine.LlmRuntime
 import dev.nucleusframework.offlinetranslator.engine.PiperVoices
+import dev.nucleusframework.offlinetranslator.platform.Platform
 import dev.nucleusframework.offlinetranslator.platform.systemUiLanguage
 import dev.nucleusframework.offlinetranslator.ui.Chip
 import dev.nucleusframework.offlinetranslator.ui.SectionLabel
@@ -156,6 +157,7 @@ private fun ModelSection(
     val ui = settings.uiLanguage
     val selected = settings.selectedModel
     val gpuAvailable by LlmRuntime.gpuAvailable.collectAsState()
+    val npuAvailable by LlmRuntime.npuAvailable.collectAsState()
     SettingsSection(stringResource(Res.string.settings_model)) {
         ChipsRow(stringResource(Res.string.settings_backend)) {
             Chip(
@@ -163,6 +165,14 @@ private fun ModelSection(
                 selected = settings.backend == LlmBackend.Auto,
                 onClick = { onIntent(AppIntent.SetLlmBackend(LlmBackend.Auto)) },
             )
+            if (Platform.osLabel == "Android") {
+                Chip(
+                    stringResource(Res.string.engine_npu),
+                    selected = settings.backend == LlmBackend.Npu,
+                    onClick = { onIntent(AppIntent.SetLlmBackend(LlmBackend.Npu)) },
+                    enabled = npuAvailable != false,
+                )
+            }
             Chip(
                 stringResource(Res.string.engine_gpu),
                 selected = settings.backend == LlmBackend.Gpu,

--- a/shared/src/commonTest/kotlin/dev/nucleusframework/offlinetranslator/AppViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/dev/nucleusframework/offlinetranslator/AppViewModelTest.kt
@@ -699,6 +699,9 @@ class AppViewModelTest {
         val gpu = seedData().let { it.copy(settings = it.settings.copy(backend = LlmBackend.Gpu)) }
         assertEquals(LlmBackend.Gpu, decodeSnapshot(encodeSnapshot(gpu)).settings.backend)
 
+        val npu = seedData().let { it.copy(settings = it.settings.copy(backend = LlmBackend.Npu)) }
+        assertEquals(LlmBackend.Npu, decodeSnapshot(encodeSnapshot(npu)).settings.backend)
+
         val legacy = encodeSnapshot(gpu).lineSequence().filterNot { it.startsWith("backend=") }.joinToString("\n")
         assertEquals(LlmBackend.Auto, decodeSnapshot(legacy).settings.backend)
     }

--- a/shared/src/commonTest/kotlin/dev/nucleusframework/offlinetranslator/LlmBackendTest.kt
+++ b/shared/src/commonTest/kotlin/dev/nucleusframework/offlinetranslator/LlmBackendTest.kt
@@ -52,4 +52,92 @@ class LlmBackendTest {
         assertEquals(LlmAccelerator.Gpu, pick.accelerator)
         assertTrue(probed)
     }
+
+    @Test
+    fun autoUsesNpuFirstWhenItWorks() {
+        var gpuProbed = false
+        val pick = pickBackend(
+            preference = LlmBackend.Auto,
+            gpuKnown = null,
+            gpuWorks = { gpuProbed = true; true },
+            npuKnown = null,
+            npuWorks = { true },
+        )
+        assertEquals(LlmAccelerator.Npu, pick.accelerator)
+        assertEquals(true, pick.npuAvailable)
+        assertFalse(gpuProbed)
+    }
+
+    @Test
+    fun autoFallsBackToGpuWhenNpuFails() {
+        val pick = pickBackend(
+            preference = LlmBackend.Auto,
+            gpuKnown = null,
+            gpuWorks = { true },
+            npuKnown = null,
+            npuWorks = { false },
+        )
+        assertEquals(LlmAccelerator.Gpu, pick.accelerator)
+        assertEquals(true, pick.gpuAvailable)
+        assertEquals(false, pick.npuAvailable)
+    }
+
+    @Test
+    fun gpuNeverProbesNpu() {
+        var npuProbed = false
+        val pick = pickBackend(
+            preference = LlmBackend.Gpu,
+            gpuKnown = null,
+            gpuWorks = { true },
+            npuKnown = null,
+            npuWorks = { npuProbed = true; true },
+        )
+        assertEquals(LlmAccelerator.Gpu, pick.accelerator)
+        assertNull(pick.npuAvailable)
+        assertFalse(npuProbed)
+    }
+
+    @Test
+    fun knownMissingNpuSkipsProbe() {
+        var npuProbed = false
+        val pick = pickBackend(
+            preference = LlmBackend.Auto,
+            gpuKnown = null,
+            gpuWorks = { true },
+            npuKnown = false,
+            npuWorks = { npuProbed = true; true },
+        )
+        assertEquals(LlmAccelerator.Gpu, pick.accelerator)
+        assertEquals(false, pick.npuAvailable)
+        assertFalse(npuProbed)
+    }
+
+    @Test
+    fun npuPreferenceFallsBackToGpu() {
+        val pick = pickBackend(
+            preference = LlmBackend.Npu,
+            gpuKnown = null,
+            gpuWorks = { true },
+            npuKnown = null,
+            npuWorks = { false },
+        )
+        assertEquals(LlmAccelerator.Gpu, pick.accelerator)
+        assertEquals(false, pick.npuAvailable)
+        assertEquals(true, pick.gpuAvailable)
+    }
+
+    @Test
+    fun cpuNeverProbesNpu() {
+        var npuProbed = false
+        val pick = pickBackend(
+            preference = LlmBackend.Cpu,
+            gpuKnown = null,
+            gpuWorks = { true },
+            npuKnown = null,
+            npuWorks = { npuProbed = true; true },
+        )
+        assertEquals(LlmAccelerator.Cpu, pick.accelerator)
+        assertNull(pick.npuAvailable)
+        assertFalse(npuProbed)
+    }
 }

--- a/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/engine/NativeLlm.jvm.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/engine/NativeLlm.jvm.kt
@@ -57,7 +57,11 @@ internal actual class NativeLlm actual constructor() {
         backend: LlmBackend,
     ): LlmAccelerator {
         loadGpuNativeLibs()
-        val pick = pickBackend(backend, LlmRuntime.gpuAvailable.value) {
+        val pick = pickBackend(
+            preference = backend,
+            gpuKnown = LlmRuntime.gpuAvailable.value,
+            npuKnown = false,
+        ) {
             val gpu = runCatching { openEngine(modelPath, cacheSubdir(cacheDir, "gpu"), Backend.GPU()) }.getOrNull()
             if (gpu != null) {
                 engine = gpu


### PR DESCRIPTION
## Summary
- Probe LiteRT-LM `Backend.NPU` first on Android when the backend is Auto or NPU, then fall back to GPU and CPU.
- Add an NPU settings chip (Android only) and show NPU on the accelerator badge when it is the one in use.
- Declare vendor NPU native libraries in the Android manifest so the process can load them.

## Test plan
- [x] `:shared:jvmTest` (including NPU pick order and snapshot round-trip)
- [x] `:androidApp:assembleDebug`
- [ ] Load a model on an NPU-capable device with Auto and confirm the badge shows NPU or falls back to GPU/CPU