### PR TITLE
feat: add experimental MTP setting, off by default

### DIFF
--- a/shared/src/androidMain/kotlin/dev/nucleusframework/offlinetranslator/engine/NativeLlm.android.kt
+++ b/shared/src/androidMain/kotlin/dev/nucleusframework/offlinetranslator/engine/NativeLlm.android.kt
@@ -6,6 +6,8 @@ import com.google.ai.edge.litertlm.Contents
 import com.google.ai.edge.litertlm.ConversationConfig
 import com.google.ai.edge.litertlm.Engine
 import com.google.ai.edge.litertlm.EngineConfig
+import com.google.ai.edge.litertlm.ExperimentalApi
+import com.google.ai.edge.litertlm.ExperimentalFlags
 import com.google.ai.edge.litertlm.SamplerConfig
 // litertlm-android 0.14.0 has no ThinkingConfig / maxOutputToken (added in 0.15+).
 // import com.google.ai.edge.litertlm.ThinkingConfig
@@ -105,7 +107,9 @@ internal actual class NativeLlm actual constructor() {
     }
 }
 
+@OptIn(ExperimentalApi::class)
 private fun openEngine(modelPath: String, cacheDir: String, backend: Backend): Engine {
+    ExperimentalFlags.enableSpeculativeDecoding = LlmRuntime.mtp
     val created = Engine(
         EngineConfig(
             modelPath = modelPath,

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -159,6 +159,10 @@
     <string name="settings_model_always_on">جاهز دائمًا</string>
     <string name="settings_model_on_demand_body">يُحمَّل عند أول ترجمة ويُفرَّغ بعد 5 دقائق من الخمول.</string>
     <string name="settings_model_always_on_body">يبقى محمّلًا لتبدأ الترجمات فورًا.</string>
+    <string name="settings_mtp">التنبؤ متعدد الرموز (تجريبي)</string>
+    <string name="settings_mtp_off">إيقاف</string>
+    <string name="settings_mtp_on">تشغيل</string>
+    <string name="settings_mtp_body">تجريبي. يتنبأ بعدة رموز دفعة واحدة. أسرع بنحو الضعف على وحدة الرسوم.</string>
     <string name="settings_model_installed">مثبّت</string>
     <string name="settings_model_missing">غير مثبّت</string>
     <string name="settings_model_downloading">جارٍ التنزيل… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-bn/strings.xml
+++ b/shared/src/commonMain/composeResources/values-bn/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">সবসময় প্রস্তুত</string>
     <string name="settings_model_on_demand_body">প্রথম অনুবাদে লোড হয় এবং ৫ মিনিট নিষ্ক্রিয় থাকলে ছেড়ে দেয়।</string>
     <string name="settings_model_always_on_body">তাৎক্ষণিক অনুবাদের জন্য লোড থাকে।</string>
+    <string name="settings_mtp">মাল্টি-টোকেন পূর্বাভাস (পরীক্ষামূলক)</string>
+    <string name="settings_mtp_off">বন্ধ</string>
+    <string name="settings_mtp_on">চালু</string>
+    <string name="settings_mtp_body">পরীক্ষামূলক। একসাথে কয়েকটি টোকেন অনুমান করে। GPU-তে প্রায় দ্বিগুণ দ্রুত।</string>
     <string name="settings_model_installed">ইনস্টল আছে</string>
     <string name="settings_model_missing">ইনস্টল নেই</string>
     <string name="settings_model_downloading">ডাউনলোড হচ্ছে… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-cs/strings.xml
+++ b/shared/src/commonMain/composeResources/values-cs/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Vždy připraven</string>
     <string name="settings_model_on_demand_body">Načte se při prvním překladu a uvolní se po 5 minutách nečinnosti.</string>
     <string name="settings_model_always_on_body">Zůstane načtený, aby překlady začínaly okamžitě.</string>
+    <string name="settings_mtp">Predikce více tokenů (experimentální)</string>
+    <string name="settings_mtp_off">Vypnuto</string>
+    <string name="settings_mtp_on">Zapnuto</string>
+    <string name="settings_mtp_body">Experimentální. Předpovídá několik tokenů najednou. Na GPU zhruba dvakrát rychlejší.</string>
     <string name="settings_model_installed">Nainstalováno</string>
     <string name="settings_model_missing">Nenainstalováno</string>
     <string name="settings_model_downloading">Stahování… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-da/strings.xml
+++ b/shared/src/commonMain/composeResources/values-da/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Altid klar</string>
     <string name="settings_model_on_demand_body">Indlæses ved den første oversættelse og frigøres efter 5 minutters inaktivitet.</string>
     <string name="settings_model_always_on_body">Forbliver indlæst, så oversættelser starter med det samme.</string>
+    <string name="settings_mtp">Multi-token-forudsigelse (eksperimentel)</string>
+    <string name="settings_mtp_off">Fra</string>
+    <string name="settings_mtp_on">Til</string>
+    <string name="settings_mtp_body">Eksperimentel. Forudsiger flere tokens på én gang. Omkring dobbelt så hurtig på GPU.</string>
     <string name="settings_model_installed">Installeret</string>
     <string name="settings_model_missing">Ikke installeret</string>
     <string name="settings_model_downloading">Downloader… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -159,6 +159,10 @@
     <string name="settings_model_always_on">Immer bereit</string>
     <string name="settings_model_on_demand_body">Wird bei der ersten Übersetzung geladen und nach 5 Minuten Inaktivität entladen.</string>
     <string name="settings_model_always_on_body">Bleibt geladen, damit Übersetzungen sofort starten.</string>
+    <string name="settings_mtp">Multi-Token-Vorhersage (experimentell)</string>
+    <string name="settings_mtp_off">Aus</string>
+    <string name="settings_mtp_on">Ein</string>
+    <string name="settings_mtp_body">Experimentell. Sagt mehrere Tokens auf einmal voraus. Auf der GPU etwa doppelt so schnell.</string>
     <string name="settings_model_installed">Installiert</string>
     <string name="settings_model_missing">Nicht installiert</string>
     <string name="settings_model_downloading">Wird heruntergeladen… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-el/strings.xml
+++ b/shared/src/commonMain/composeResources/values-el/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Πάντα έτοιμο</string>
     <string name="settings_model_on_demand_body">Φορτώνεται στην πρώτη μετάφραση και αποφορτώνεται μετά από 5 λεπτά αδράνειας.</string>
     <string name="settings_model_always_on_body">Παραμένει φορτωμένο ώστε οι μεταφράσεις να ξεκινούν αμέσως.</string>
+    <string name="settings_mtp">Πρόβλεψη πολλαπλών token (πειραματικό)</string>
+    <string name="settings_mtp_off">Ανενεργή</string>
+    <string name="settings_mtp_on">Ενεργή</string>
+    <string name="settings_mtp_body">Πειραματικό. Προβλέπει πολλά token μαζί. Περίπου δύο φορές ταχύτερη σε GPU.</string>
     <string name="settings_model_installed">Εγκατεστημένο</string>
     <string name="settings_model_missing">Δεν έχει εγκατασταθεί</string>
     <string name="settings_model_downloading">Λήψη… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -159,6 +159,10 @@
     <string name="settings_model_always_on">Siempre listo</string>
     <string name="settings_model_on_demand_body">Se carga en la primera traducción y se descarga tras 5 minutos de inactividad.</string>
     <string name="settings_model_always_on_body">Permanece cargado para que las traducciones empiecen al instante.</string>
+    <string name="settings_mtp">Predicción multi-token (experimental)</string>
+    <string name="settings_mtp_off">Desactivada</string>
+    <string name="settings_mtp_on">Activada</string>
+    <string name="settings_mtp_body">Experimental. Predice varios tokens a la vez. Unas dos veces más rápida en GPU.</string>
     <string name="settings_model_installed">Instalado</string>
     <string name="settings_model_missing">No instalado</string>
     <string name="settings_model_downloading">Descargando… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-fa/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fa/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">همیشه آماده</string>
     <string name="settings_model_on_demand_body">در نخستین ترجمه بارگذاری می‌شود و پس از ۵ دقیقه بی‌فعالیتی آزاد می‌گردد.</string>
     <string name="settings_model_always_on_body">بارگذاری‌شده می‌ماند تا ترجمه فوری آغاز شود.</string>
+    <string name="settings_mtp">پیش‌بینی چندتوکنی (آزمایشی)</string>
+    <string name="settings_mtp_off">خاموش</string>
+    <string name="settings_mtp_on">روشن</string>
+    <string name="settings_mtp_body">آزمایشی. چند توکن را یکجا پیش‌بینی می‌کند. روی GPU حدود دو برابر سریع‌تر است.</string>
     <string name="settings_model_installed">نصب‌شده</string>
     <string name="settings_model_missing">نصب نشده</string>
     <string name="settings_model_downloading">در حال دانلود… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-fi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fi/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Aina valmiina</string>
     <string name="settings_model_on_demand_body">Ladataan ensimmäisessä käännöksessä ja vapautetaan 5 minuutin käyttämättömyyden jälkeen.</string>
     <string name="settings_model_always_on_body">Pysyy ladattuna, jotta käännökset alkavat heti.</string>
+    <string name="settings_mtp">Monitoken-ennustus (kokeellinen)</string>
+    <string name="settings_mtp_off">Pois</string>
+    <string name="settings_mtp_on">Päällä</string>
+    <string name="settings_mtp_body">Kokeellinen. Ennustaa useita tokeneita kerralla. GPU:lla noin kaksi kertaa nopeampi.</string>
     <string name="settings_model_installed">Asennettu</string>
     <string name="settings_model_missing">Ei asennettu</string>
     <string name="settings_model_downloading">Ladataan… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-fil/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fil/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Laging handa</string>
     <string name="settings_model_on_demand_body">Naglo-load sa unang pagsasalin at nagre-release pagkatapos ng 5 minutong walang galaw.</string>
     <string name="settings_model_always_on_body">Nanatiling naka-load para agad magsimula ang pagsasalin.</string>
+    <string name="settings_mtp">Multi-token prediction (eksperimento)</string>
+    <string name="settings_mtp_off">Naka-off</string>
+    <string name="settings_mtp_on">Naka-on</string>
+    <string name="settings_mtp_body">Eksperimento. Humuhula ng ilang token nang sabay. Mga doble ang bilis sa GPU.</string>
     <string name="settings_model_installed">Naka-install</string>
     <string name="settings_model_missing">Hindi naka-install</string>
     <string name="settings_model_downloading">Dina-download… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -159,6 +159,10 @@
     <string name="settings_model_always_on">Toujours actif</string>
     <string name="settings_model_on_demand_body">Chargé au premier message, libéré après 5 min d'inactivité.</string>
     <string name="settings_model_always_on_body">Reste chargé pour des traductions instantanées.</string>
+    <string name="settings_mtp">Prédiction multi-jetons (expérimental)</string>
+    <string name="settings_mtp_off">Désactivée</string>
+    <string name="settings_mtp_on">Activée</string>
+    <string name="settings_mtp_body">Expérimental. Prédit plusieurs jetons à la fois. Environ deux fois plus rapide sur GPU.</string>
     <string name="settings_model_installed">Installé</string>
     <string name="settings_model_missing">Non installé</string>
     <string name="settings_model_downloading">Téléchargement… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-he/strings.xml
+++ b/shared/src/commonMain/composeResources/values-he/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">תמיד מוכן</string>
     <string name="settings_model_on_demand_body">נטען בתרגום הראשון ומשתחרר אחרי 5 דקות ללא פעילות.</string>
     <string name="settings_model_always_on_body">נשאר טעון כדי שהתרגומים יתחילו מיד.</string>
+    <string name="settings_mtp">חיזוי רב-אסימונים (ניסיוני)</string>
+    <string name="settings_mtp_off">כבוי</string>
+    <string name="settings_mtp_on">פעיל</string>
+    <string name="settings_mtp_body">ניסיוני. חוזה כמה אסימונים בבת אחת. מהיר פי שניים בערך ב-GPU.</string>
     <string name="settings_model_installed">מותקן</string>
     <string name="settings_model_missing">לא מותקן</string>
     <string name="settings_model_downloading">מוריד… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">हमेशा तैयार</string>
     <string name="settings_model_on_demand_body">पहली बार अनुवाद पर लोड होता है और 5 मिनट निष्क्रिय रहने पर मुक्त होता है।</string>
     <string name="settings_model_always_on_body">तुरंत अनुवाद शुरू करने के लिए लोड रहता है।</string>
+    <string name="settings_mtp">मल्टी-टोकन पूर्वानुमान (प्रयोगात्मक)</string>
+    <string name="settings_mtp_off">बंद</string>
+    <string name="settings_mtp_on">चालू</string>
+    <string name="settings_mtp_body">प्रयोगात्मक. एक साथ कई टोकन का अनुमान लगाता है। GPU पर लगभग दोगुना तेज़।</string>
     <string name="settings_model_installed">इंस्टॉल है</string>
     <string name="settings_model_missing">इंस्टॉल नहीं</string>
     <string name="settings_model_downloading">डाउनलोड हो रहा है… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-hr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hr/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Uvijek spreman</string>
     <string name="settings_model_on_demand_body">Učitava se pri prvom prijevodu i oslobađa nakon 5 minuta neaktivnosti.</string>
     <string name="settings_model_always_on_body">Ostaje učitan kako bi prijevodi krenuli odmah.</string>
+    <string name="settings_mtp">Predikcija više tokena (eksperimentalno)</string>
+    <string name="settings_mtp_off">Isključeno</string>
+    <string name="settings_mtp_on">Uključeno</string>
+    <string name="settings_mtp_body">Eksperimentalno. Predviđa nekoliko tokena odjednom. Na GPU-u otprilike dvostruko brže.</string>
     <string name="settings_model_installed">Instalirano</string>
     <string name="settings_model_missing">Nije instalirano</string>
     <string name="settings_model_downloading">Preuzimanje… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-hu/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hu/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Mindig kész</string>
     <string name="settings_model_on_demand_body">Az első fordításkor töltődik be, és 5 perc tétlenség után felszabadul.</string>
     <string name="settings_model_always_on_body">Betöltve marad, hogy a fordítások azonnal induljanak.</string>
+    <string name="settings_mtp">Többtokenes előrejelzés (kísérleti)</string>
+    <string name="settings_mtp_off">Ki</string>
+    <string name="settings_mtp_on">Be</string>
+    <string name="settings_mtp_body">Kísérleti. Több tokent jósol egyszerre. GPU-n körülbelül kétszer gyorsabb.</string>
     <string name="settings_model_installed">Telepítve</string>
     <string name="settings_model_missing">Nincs telepítve</string>
     <string name="settings_model_downloading">Letöltés… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-id/strings.xml
+++ b/shared/src/commonMain/composeResources/values-id/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Selalu siap</string>
     <string name="settings_model_on_demand_body">Dimuat pada terjemahan pertama dan dilepas setelah 5 menit tidak aktif.</string>
     <string name="settings_model_always_on_body">Tetap dimuat agar terjemahan langsung dimulai.</string>
+    <string name="settings_mtp">Prediksi multi-token (eksperimental)</string>
+    <string name="settings_mtp_off">Nonaktif</string>
+    <string name="settings_mtp_on">Aktif</string>
+    <string name="settings_mtp_body">Eksperimental. Memprediksi beberapa token sekaligus. Sekitar dua kali lebih cepat di GPU.</string>
     <string name="settings_model_installed">Terpasang</string>
     <string name="settings_model_missing">Belum terpasang</string>
     <string name="settings_model_downloading">Mengunduh… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -159,6 +159,10 @@
     <string name="settings_model_always_on">Sempre pronto</string>
     <string name="settings_model_on_demand_body">Si carica alla prima traduzione e si scarica dopo 5 minuti di inattività.</string>
     <string name="settings_model_always_on_body">Resta caricato per traduzioni istantanee.</string>
+    <string name="settings_mtp">Predizione multi-token (sperimentale)</string>
+    <string name="settings_mtp_off">Disattivata</string>
+    <string name="settings_mtp_on">Attivata</string>
+    <string name="settings_mtp_body">Sperimentale. Predice più token insieme. Circa due volte più veloce su GPU.</string>
     <string name="settings_model_installed">Installato</string>
     <string name="settings_model_missing">Non installato</string>
     <string name="settings_model_downloading">Download… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -159,6 +159,10 @@
     <string name="settings_model_always_on">常時準備</string>
     <string name="settings_model_on_demand_body">最初の翻訳で読み込み、5分間操作がなければ解放します。</string>
     <string name="settings_model_always_on_body">読み込んだままにして翻訳をすぐ開始します。</string>
+    <string name="settings_mtp">マルチトークン予測（実験的）</string>
+    <string name="settings_mtp_off">オフ</string>
+    <string name="settings_mtp_on">オン</string>
+    <string name="settings_mtp_body">実験的機能です。複数のトークンを一度に予測します。GPUでは約2倍速くなります。</string>
     <string name="settings_model_installed">インストール済み</string>
     <string name="settings_model_missing">未インストール</string>
     <string name="settings_model_downloading">ダウンロード中… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-ko/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ko/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">항상 준비</string>
     <string name="settings_model_on_demand_body">첫 번역 때 로드되고 5분 동안 사용하지 않으면 해제됩니다.</string>
     <string name="settings_model_always_on_body">즉시 번역되도록 로드된 상태를 유지합니다.</string>
+    <string name="settings_mtp">멀티 토큰 예측 (실험적)</string>
+    <string name="settings_mtp_off">끔</string>
+    <string name="settings_mtp_on">켬</string>
+    <string name="settings_mtp_body">실험적 기능입니다. 여러 토큰을 한 번에 예측합니다. GPU에서 약 두 배 빠릅니다.</string>
     <string name="settings_model_installed">설치됨</string>
     <string name="settings_model_missing">설치되지 않음</string>
     <string name="settings_model_downloading">다운로드 중… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-mi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-mi/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Kua rite tonu</string>
     <string name="settings_model_on_demand_body">Ka utaina i te whakamāori tuatahi, ka tukuna i muri i te 5 meneti kāore e mahi.</string>
     <string name="settings_model_always_on_body">Ka noho utaina kia tīmata wawe ngā whakamāori.</string>
+    <string name="settings_mtp">Matapae tohu-maha (whakamātau)</string>
+    <string name="settings_mtp_off">Weto</string>
+    <string name="settings_mtp_on">Kā</string>
+    <string name="settings_mtp_body">Whakamātau. Ka matapae ētahi tohu i te wā kotahi. Tata rua te tere i te GPU.</string>
     <string name="settings_model_installed">Kua tāuta</string>
     <string name="settings_model_missing">Kāore i tāutaina</string>
     <string name="settings_model_downloading">E tikiake ana… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -159,6 +159,10 @@
     <string name="settings_model_always_on">Altijd klaar</string>
     <string name="settings_model_on_demand_body">Laadt bij de eerste vertaling en ontlaadt na 5 minuten inactiviteit.</string>
     <string name="settings_model_always_on_body">Blijft geladen zodat vertalingen meteen starten.</string>
+    <string name="settings_mtp">Multi-tokenvoorspelling (experimenteel)</string>
+    <string name="settings_mtp_off">Uit</string>
+    <string name="settings_mtp_on">Aan</string>
+    <string name="settings_mtp_body">Experimenteel. Voorspelt meerdere tokens tegelijk. Ongeveer twee keer zo snel op GPU.</string>
     <string name="settings_model_installed">Geïnstalleerd</string>
     <string name="settings_model_missing">Niet geïnstalleerd</string>
     <string name="settings_model_downloading">Downloaden… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-no/strings.xml
+++ b/shared/src/commonMain/composeResources/values-no/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Alltid klar</string>
     <string name="settings_model_on_demand_body">Lastes ved første oversettelse og frigjøres etter 5 minutter inaktivitet.</string>
     <string name="settings_model_always_on_body">Forblir lastet slik at oversettelser starter med en gang.</string>
+    <string name="settings_mtp">Multi-token-prediksjon (eksperimentell)</string>
+    <string name="settings_mtp_off">Av</string>
+    <string name="settings_mtp_on">På</string>
+    <string name="settings_mtp_body">Eksperimentell. Forutsier flere tokens samtidig. Omtrent dobbelt så rask på GPU.</string>
     <string name="settings_model_installed">Installert</string>
     <string name="settings_model_missing">Ikke installert</string>
     <string name="settings_model_downloading">Laster ned… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-pl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pl/strings.xml
@@ -159,6 +159,10 @@
     <string name="settings_model_always_on">Zawsze gotowy</string>
     <string name="settings_model_on_demand_body">Ładuje się przy pierwszym tłumaczeniu i zwalnia po 5 minutach bezczynności.</string>
     <string name="settings_model_always_on_body">Pozostaje załadowany, aby tłumaczenia startowały natychmiast.</string>
+    <string name="settings_mtp">Predykcja wielu tokenów (eksperymentalna)</string>
+    <string name="settings_mtp_off">Wyłączona</string>
+    <string name="settings_mtp_on">Włączona</string>
+    <string name="settings_mtp_body">Eksperymentalne. Przewiduje kilka tokenów naraz. Na GPU około dwa razy szybciej.</string>
     <string name="settings_model_installed">Zainstalowany</string>
     <string name="settings_model_missing">Niezainstalowany</string>
     <string name="settings_model_downloading">Pobieranie… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -159,6 +159,10 @@
     <string name="settings_model_always_on">Sempre pronto</string>
     <string name="settings_model_on_demand_body">Carrega na primeira tradução e descarrega após 5 minutos de inatividade.</string>
     <string name="settings_model_always_on_body">Permanece carregado para traduções instantâneas.</string>
+    <string name="settings_mtp">Predição multi-token (experimental)</string>
+    <string name="settings_mtp_off">Desativada</string>
+    <string name="settings_mtp_on">Ativada</string>
+    <string name="settings_mtp_body">Experimental. Prevê vários tokens de uma vez. Cerca de duas vezes mais rápida na GPU.</string>
     <string name="settings_model_installed">Instalado</string>
     <string name="settings_model_missing">Não instalado</string>
     <string name="settings_model_downloading">A descarregar… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-ro/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ro/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Mereu gata</string>
     <string name="settings_model_on_demand_body">Se încarcă la prima traducere și se eliberează după 5 minute de inactivitate.</string>
     <string name="settings_model_always_on_body">Rămâne încărcat ca traducerile să pornească instant.</string>
+    <string name="settings_mtp">Predicție multi-token (experimental)</string>
+    <string name="settings_mtp_off">Dezactivată</string>
+    <string name="settings_mtp_on">Activată</string>
+    <string name="settings_mtp_body">Experimental. Prezice mai mulți tokeni deodată. De aproximativ două ori mai rapidă pe GPU.</string>
     <string name="settings_model_installed">Instalat</string>
     <string name="settings_model_missing">Neinstalat</string>
     <string name="settings_model_downloading">Se descarcă… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -159,6 +159,10 @@
     <string name="settings_model_always_on">Всегда готов</string>
     <string name="settings_model_on_demand_body">Загружается при первом переводе и выгружается после 5 минут простоя.</string>
     <string name="settings_model_always_on_body">Остаётся загруженной, чтобы переводы начинались сразу.</string>
+    <string name="settings_mtp">Мультитокенное предсказание (экспериментально)</string>
+    <string name="settings_mtp_off">Выкл.</string>
+    <string name="settings_mtp_on">Вкл.</string>
+    <string name="settings_mtp_body">Экспериментально. Предсказывает несколько токенов сразу. На GPU примерно в два раза быстрее.</string>
     <string name="settings_model_installed">Установлена</string>
     <string name="settings_model_missing">Не установлена</string>
     <string name="settings_model_downloading">Загрузка… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-sv/strings.xml
+++ b/shared/src/commonMain/composeResources/values-sv/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Alltid redo</string>
     <string name="settings_model_on_demand_body">Laddas vid första översättningen och släpps efter 5 minuters inaktivitet.</string>
     <string name="settings_model_always_on_body">Stannar laddad så att översättningar startar direkt.</string>
+    <string name="settings_mtp">Multitoken-förutsägelse (experimentell)</string>
+    <string name="settings_mtp_off">Av</string>
+    <string name="settings_mtp_on">På</string>
+    <string name="settings_mtp_body">Experimentell. Förutsäger flera token på en gång. Ungefär dubbelt så snabb på GPU.</string>
     <string name="settings_model_installed">Installerad</string>
     <string name="settings_model_missing">Inte installerad</string>
     <string name="settings_model_downloading">Laddar ner… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-sw/strings.xml
+++ b/shared/src/commonMain/composeResources/values-sw/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Tayari daima</string>
     <string name="settings_model_on_demand_body">Inapakia kwenye tafsiri ya kwanza na kuachilia baada ya dakika 5 bila matumizi.</string>
     <string name="settings_model_always_on_body">Inabaki imepakiwa ili tafsiri zianze mara moja.</string>
+    <string name="settings_mtp">Utabiri wa tokeni nyingi (majaribio)</string>
+    <string name="settings_mtp_off">Imezimwa</string>
+    <string name="settings_mtp_on">Imewashwa</string>
+    <string name="settings_mtp_body">Majaribio. Hutabiri tokeni kadhaa kwa pamoja. Takriban mara mbili haraka kwenye GPU.</string>
     <string name="settings_model_installed">Imesakinishwa</string>
     <string name="settings_model_missing">Haijasakinishwa</string>
     <string name="settings_model_downloading">Inapakua… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-te/strings.xml
+++ b/shared/src/commonMain/composeResources/values-te/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">ఎప్పుడూ సిద్ధం</string>
     <string name="settings_model_on_demand_body">మొదటి అనువాదంలో లోడ్ అవుతుంది, 5 నిమిషాల నిష్క్రియం తర్వాత విడుదలవుతుంది.</string>
     <string name="settings_model_always_on_body">అనువాదాలు వెంటనే మొదలయ్యేలా లోడ్‌లో ఉంటుంది.</string>
+    <string name="settings_mtp">మల్టీ-టోకెన్ అంచనా (ప్రయోగాత్మకం)</string>
+    <string name="settings_mtp_off">ఆఫ్</string>
+    <string name="settings_mtp_on">ఆన్</string>
+    <string name="settings_mtp_body">ప్రయోగాత్మకం. ఒకేసారి పలు టోకెన్లను అంచనా వేస్తుంది. GPUపై దాదాపు రెండు రెట్లు వేగం.</string>
     <string name="settings_model_installed">ఇన్‌స్టాల్ అయింది</string>
     <string name="settings_model_missing">ఇన్‌స్టాల్ లేదు</string>
     <string name="settings_model_downloading">డౌన్‌లోడ్ అవుతోంది… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-th/strings.xml
+++ b/shared/src/commonMain/composeResources/values-th/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">พร้อมเสมอ</string>
     <string name="settings_model_on_demand_body">โหลดเมื่อแปลครั้งแรก และปล่อยหลังไม่ใช้งาน 5 นาที</string>
     <string name="settings_model_always_on_body">คงโหลดไว้เพื่อให้แปลได้ทันที</string>
+    <string name="settings_mtp">การทำนายหลายโทเคน (ทดลอง)</string>
+    <string name="settings_mtp_off">ปิด</string>
+    <string name="settings_mtp_on">เปิด</string>
+    <string name="settings_mtp_body">ฟีเจอร์ทดลอง ทำนายหลายโทเคนพร้อมกัน บน GPU เร็วขึ้นประมาณสองเท่า</string>
     <string name="settings_model_installed">ติดตั้งแล้ว</string>
     <string name="settings_model_missing">ยังไม่ติดตั้ง</string>
     <string name="settings_model_downloading">กำลังดาวน์โหลด… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-tr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tr/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Her zaman hazır</string>
     <string name="settings_model_on_demand_body">İlk çeviride yüklenir ve 5 dakika hareketsizlikten sonra bellekten çıkar.</string>
     <string name="settings_model_always_on_body">Çevirilerin anında başlaması için yüklü kalır.</string>
+    <string name="settings_mtp">Çoklu jeton tahmini (deneysel)</string>
+    <string name="settings_mtp_off">Kapalı</string>
+    <string name="settings_mtp_on">Açık</string>
+    <string name="settings_mtp_body">Deneysel. Birden fazla jetonu bir anda tahmin eder. GPU'da yaklaşık iki kat hızlıdır.</string>
     <string name="settings_model_installed">Kurulu</string>
     <string name="settings_model_missing">Kurulu değil</string>
     <string name="settings_model_downloading">İndiriliyor… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Завжди готовий</string>
     <string name="settings_model_on_demand_body">Завантажується під час першого перекладу і вивантажується після 5 хвилин простою.</string>
     <string name="settings_model_always_on_body">Залишається завантаженою, щоб переклади починалися одразу.</string>
+    <string name="settings_mtp">Мультитокенне передбачення (експериментально)</string>
+    <string name="settings_mtp_off">Вимк.</string>
+    <string name="settings_mtp_on">Увімк.</string>
+    <string name="settings_mtp_body">Експериментально. Передбачає кілька токенів одразу. На GPU приблизно вдвічі швидше.</string>
     <string name="settings_model_installed">Встановлено</string>
     <string name="settings_model_missing">Не встановлено</string>
     <string name="settings_model_downloading">Завантаження… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-vi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-vi/strings.xml
@@ -153,6 +153,10 @@
     <string name="settings_model_always_on">Luôn sẵn sàng</string>
     <string name="settings_model_on_demand_body">Tải khi dịch lần đầu và giải phóng sau 5 phút không dùng.</string>
     <string name="settings_model_always_on_body">Giữ tải sẵn để bản dịch bắt đầu ngay.</string>
+    <string name="settings_mtp">Dự đoán đa token (thử nghiệm)</string>
+    <string name="settings_mtp_off">Tắt</string>
+    <string name="settings_mtp_on">Bật</string>
+    <string name="settings_mtp_body">Thử nghiệm. Dự đoán nhiều token cùng lúc. Nhanh gấp khoảng hai lần trên GPU.</string>
     <string name="settings_model_installed">Đã cài</string>
     <string name="settings_model_missing">Chưa cài</string>
     <string name="settings_model_downloading">Đang tải… %1$s</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -159,6 +159,10 @@
     <string name="settings_model_always_on">始终就绪</string>
     <string name="settings_model_on_demand_body">首次翻译时加载，空闲 5 分钟后卸载。</string>
     <string name="settings_model_always_on_body">保持加载以便立即开始翻译。</string>
+    <string name="settings_mtp">多词元预测（实验性）</string>
+    <string name="settings_mtp_off">关</string>
+    <string name="settings_mtp_on">开</string>
+    <string name="settings_mtp_body">实验性功能。一次预测多个词元。在 GPU 上大约快一倍。</string>
     <string name="settings_model_installed">已安装</string>
     <string name="settings_model_missing">未安装</string>
     <string name="settings_model_downloading">正在下载… %1$s</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -159,6 +159,10 @@
     <string name="settings_model_always_on">Always ready</string>
     <string name="settings_model_on_demand_body">Loads on the first translation and unloads after 5 minutes idle.</string>
     <string name="settings_model_always_on_body">Stays loaded so translations start instantly.</string>
+    <string name="settings_mtp">Multi-token prediction (experimental)</string>
+    <string name="settings_mtp_off">Off</string>
+    <string name="settings_mtp_on">On</string>
+    <string name="settings_mtp_body">Experimental. Predicts several tokens at once. About twice as fast on GPU.</string>
     <string name="settings_model_installed">Installed</string>
     <string name="settings_model_missing">Not installed</string>
     <string name="settings_model_downloading">Downloading… %1$s</string>

--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/app/AppIntent.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/app/AppIntent.kt
@@ -52,6 +52,7 @@ sealed interface AppIntent {
     data class SetLangNameStyle(val style: LangNameStyle) : AppIntent
     data class SetLlmBackend(val backend: LlmBackend) : AppIntent
     data class SetLlmKeepAlive(val mode: LlmKeepAlive) : AppIntent
+    data class SetMtp(val on: Boolean) : AppIntent
 
     data object PauseDownload : AppIntent
     data object ResumeDownload : AppIntent

--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/app/AppViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/app/AppViewModel.kt
@@ -234,6 +234,12 @@ class AppViewModel(
                 preloadIfKeptReady(_state.value.data.model.path)
             }
 
+            is AppIntent.SetMtp -> {
+                LlmRuntime.mtp = intent.on
+                persist(now = true)
+                preloadIfKeptReady(_state.value.data.model.path)
+            }
+
             is AppIntent.SetLlmKeepAlive -> {
                 persist(now = true)
                 if (intent.mode == LlmKeepAlive.AlwaysOn) {
@@ -333,6 +339,7 @@ class AppViewModel(
         val ram = hostRamBytes()
         data = coerceModelForRam(data, ram)
         LlmRuntime.preference = data.settings.backend
+        LlmRuntime.mtp = data.settings.mtp
         val catalog = GemmaModels.of(data.settings.selectedModel)
         if (modelOnDisk(catalog) && (!data.model.installed || data.model.id != catalog.id)) {
             data = data.copy(model = catalog.toInfo(clock()))
@@ -493,6 +500,8 @@ class AppViewModel(
         is AppIntent.SetLlmBackend -> s.updateSettings { it.copy(backend = intent.backend) }
 
         is AppIntent.SetLlmKeepAlive -> s.updateSettings { it.copy(keepAlive = intent.mode) }
+
+        is AppIntent.SetMtp -> s.updateSettings { it.copy(mtp = intent.on) }
 
         is AppIntent.DownloadTick -> s.copy(
             download = s.download.copy(
@@ -764,6 +773,7 @@ class AppViewModel(
         scope.launch { runCatching { mic.stop() } }
         unloadEngine()
         LlmRuntime.preference = LlmBackend.Auto
+        LlmRuntime.mtp = false
         GemmaModels.all.forEach { catalog ->
             if (modelOwnedByApp(catalog)) deleteModelFiles(catalog)
             else Platform.delete(catalog.partialPath())

--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/data/SnapshotCodec.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/data/SnapshotCodec.kt
@@ -37,6 +37,7 @@ internal fun encodeSnapshot(data: AppData): String = buildString {
     appendLine("selectedModel=${s.selectedModel.name}")
     appendLine("backend=${s.backend.name}")
     appendLine("keepAlive=${s.keepAlive.name}")
+    appendLine("mtp=${s.mtp}")
     appendLine("langNames=${s.langNames.name}")
     appendLine("selectedVoices=${s.selectedVoices.entries.joinToString(",") { "${it.key}=${it.value}" }}")
     val m = data.model
@@ -75,6 +76,7 @@ internal fun decodeSnapshot(text: String): AppData {
     var selectedModel = LlmModel.Fast
     var backend = LlmBackend.Auto
     var keepAlive = LlmKeepAlive.OnDemand
+    var mtp = false
     var langNames = LangNameStyle.System
     var selectedVoices = emptyMap<String, String>()
     var modelId = LlmModel.Fast
@@ -127,6 +129,8 @@ internal fun decodeSnapshot(text: String): AppData {
                 keepAlive =
                     runCatching { LlmKeepAlive.valueOf(line.substringAfter("=")) }.getOrDefault(LlmKeepAlive.OnDemand)
 
+            line.startsWith("mtp=") -> mtp = line.substringAfter("=").toBoolean()
+
             line.startsWith("langNames=") ->
                 langNames =
                     runCatching { LangNameStyle.valueOf(line.substringAfter("=")) }.getOrDefault(LangNameStyle.System)
@@ -174,6 +178,7 @@ internal fun decodeSnapshot(text: String): AppData {
             selectedModel = selectedModel,
             backend = backend,
             keepAlive = keepAlive,
+            mtp = mtp,
             langNames = langNames,
             selectedVoices = selectedVoices,
         ),

--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/domain/Models.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/domain/Models.kt
@@ -135,6 +135,8 @@ data class UserSettings(
     val selectedModel: LlmModel = LlmModel.Fast,
     val backend: LlmBackend = LlmBackend.Auto,
     val keepAlive: LlmKeepAlive = LlmKeepAlive.OnDemand,
+    /** Gemma 4 multi-token prediction. Off by default — opt in from Settings. */
+    val mtp: Boolean = false,
     val langNames: LangNameStyle = LangNameStyle.System,
     val selectedVoices: Map<String, String> = emptyMap(),
 )

--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/engine/GemmaTranslator.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/engine/GemmaTranslator.kt
@@ -25,6 +25,7 @@ class GemmaTranslator(
     private var session: NativeLlm? = null
     private var loadedPath: String? = null
     private var loadedBackend: LlmBackend? = null
+    private var loadedMtp: Boolean? = null
 
     override suspend fun translate(request: TranslationRequest): TranslationResult {
         val path = request.modelPath
@@ -94,17 +95,20 @@ class GemmaTranslator(
         session = null
         loadedPath = null
         loadedBackend = null
+        loadedMtp = null
         LlmRuntime.report(LlmAccelerator.None)
     }
 
     private fun ensureLoaded(path: String): NativeLlm {
         val pref = LlmRuntime.preference
+        val mtp = LlmRuntime.mtp
         val current = session
-        if (current != null && loadedPath == path && loadedBackend == pref) return current
+        if (current != null && loadedPath == path && loadedBackend == pref && loadedMtp == mtp) return current
         current?.close()
         session = null
         loadedPath = null
         loadedBackend = null
+        loadedMtp = null
         val dir = cacheDir()
         Platform.mkdir(dir)
         val next = sessionFactory()
@@ -113,6 +117,7 @@ class GemmaTranslator(
             session = next
             loadedPath = path
             loadedBackend = pref
+            loadedMtp = mtp
             LlmRuntime.report(used)
             return next
         } catch (t: Throwable) {

--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/engine/LlmAccelerator.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/engine/LlmAccelerator.kt
@@ -11,6 +11,10 @@ object LlmRuntime {
     @Volatile
     var preference: LlmBackend = LlmBackend.Auto
 
+    /** Gemma 4 MTP. Read when a new Engine is created. */
+    @Volatile
+    var mtp: Boolean = false
+
     private val _accelerator = MutableStateFlow(LlmAccelerator.None)
     val accelerator: StateFlow<LlmAccelerator> = _accelerator.asStateFlow()
 

--- a/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/main/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/dev/nucleusframework/offlinetranslator/main/SettingsScreen.kt
@@ -211,6 +211,25 @@ private fun ModelSection(
             modifier = Modifier.padding(start = 20.dp, end = 20.dp, bottom = 14.dp),
         )
         Divider()
+        ChipsRow(stringResource(Res.string.settings_mtp)) {
+            Chip(
+                stringResource(Res.string.settings_mtp_off),
+                selected = !settings.mtp,
+                onClick = { onIntent(AppIntent.SetMtp(false)) },
+            )
+            Chip(
+                stringResource(Res.string.settings_mtp_on),
+                selected = settings.mtp,
+                onClick = { onIntent(AppIntent.SetMtp(true)) },
+            )
+        }
+        Text(
+            stringResource(Res.string.settings_mtp_body),
+            fontSize = 13.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 20.dp, end = 20.dp, bottom = 14.dp),
+        )
+        Divider()
         Divided(GemmaModels.all) { catalog ->
             val installed = catalog.isOnDisk() || (model.installed && model.id == catalog.id)
             val mine = catalog.id == selected

--- a/shared/src/commonTest/kotlin/dev/nucleusframework/offlinetranslator/AppViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/dev/nucleusframework/offlinetranslator/AppViewModelTest.kt
@@ -295,12 +295,15 @@ class AppViewModelTest {
         vm.onIntent(AppIntent.SetLangNameStyle(LangNameStyle.Native))
         vm.onIntent(AppIntent.SetLlmBackend(LlmBackend.Cpu))
         vm.onIntent(AppIntent.SetLlmKeepAlive(LlmKeepAlive.AlwaysOn))
+        vm.onIntent(AppIntent.SetMtp(true))
         val loaded = store.load()
         assertEquals(LlmModel.Precise, loaded.settings.selectedModel)
         assertEquals(UiLanguage.En, loaded.settings.uiLanguage)
         assertEquals(LangNameStyle.Native, loaded.settings.langNames)
         assertEquals(LlmBackend.Cpu, loaded.settings.backend)
         assertEquals(LlmKeepAlive.AlwaysOn, loaded.settings.keepAlive)
+        assertTrue(loaded.settings.mtp)
+        vm.onIntent(AppIntent.SetMtp(false))
     }
 
     @Test
@@ -660,6 +663,7 @@ class AppViewModelTest {
                 langNames = LangNameStyle.Native,
                 backend = LlmBackend.Gpu,
                 keepAlive = LlmKeepAlive.AlwaysOn,
+                mtp = true,
             ),
             model = seedData().model.copy(id = LlmModel.Precise, installed = true),
         )
@@ -669,6 +673,7 @@ class AppViewModelTest {
         assertEquals(LangNameStyle.Native, restored.settings.langNames)
         assertEquals(LlmBackend.Gpu, restored.settings.backend)
         assertEquals(LlmKeepAlive.AlwaysOn, restored.settings.keepAlive)
+        assertTrue(restored.settings.mtp)
         assertEquals(original.lastSourceLang, restored.lastSourceLang)
         assertEquals(original.lastTargetLang, restored.lastTargetLang)
         assertEquals(LlmModel.Precise, restored.model.id)
@@ -713,6 +718,15 @@ class AppViewModelTest {
 
         val legacy = encodeSnapshot(always).lineSequence().filterNot { it.startsWith("keepAlive=") }.joinToString("\n")
         assertEquals(LlmKeepAlive.OnDemand, decodeSnapshot(legacy).settings.keepAlive)
+    }
+
+    @Test
+    fun mtpSurvivesRoundTripAndDefaultsOffForOlderSnapshots() {
+        val on = seedData().let { it.copy(settings = it.settings.copy(mtp = true)) }
+        assertTrue(decodeSnapshot(encodeSnapshot(on)).settings.mtp)
+
+        val legacy = encodeSnapshot(on).lineSequence().filterNot { it.startsWith("mtp=") }.joinToString("\n")
+        assertFalse(decodeSnapshot(legacy).settings.mtp)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/engine/LinuxGpuWorker.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/engine/LinuxGpuWorker.kt
@@ -107,7 +107,10 @@ internal class LinuxGpuWorkerProcess(
             val command = workerCommand(modelPath, cacheDir, threads) ?: return null
             val process = ProcessBuilder(command)
                 .redirectError(ProcessBuilder.Redirect.INHERIT)
-                .apply { environment()["EDGE_TRANSLATOR_GPU_WORKER"] = "1" }
+                .apply {
+                    environment()["EDGE_TRANSLATOR_GPU_WORKER"] = "1"
+                    environment()["EDGE_TRANSLATOR_MTP"] = if (LlmRuntime.mtp) "1" else "0"
+                }
                 .start()
             val reader = process.inputStream.bufferedReader()
             val writer = process.outputStream.bufferedWriter()
@@ -137,6 +140,7 @@ fun runGpuWorker(args: Array<String>) {
     val threads = args.getOrNull(2)?.toIntOrNull() ?: 0
     val llm = NativeLlm()
     try {
+        LlmRuntime.mtp = System.getenv("EDGE_TRANSLATOR_MTP") == "1"
         llm.loadInProcess(modelPath, cacheDir, threads, LlmBackend.Gpu)
         println("READY")
         System.out.flush()

--- a/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/engine/NativeLlm.jvm.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/engine/NativeLlm.jvm.kt
@@ -7,6 +7,8 @@ import com.google.ai.edge.litertlm.Conversation
 import com.google.ai.edge.litertlm.ConversationConfig
 import com.google.ai.edge.litertlm.Engine
 import com.google.ai.edge.litertlm.EngineConfig
+import com.google.ai.edge.litertlm.ExperimentalApi
+import com.google.ai.edge.litertlm.ExperimentalFlags
 import com.google.ai.edge.litertlm.SamplerConfig
 // litertlm-jvm 0.14.0 has no ThinkingConfig / maxOutputToken (added in 0.15+).
 // import com.google.ai.edge.litertlm.ThinkingConfig
@@ -194,7 +196,9 @@ internal actual class NativeLlm actual constructor() {
     }
 }
 
+@OptIn(ExperimentalApi::class)
 private fun openEngine(modelPath: String, cacheDir: String, backend: Backend): Engine {
+    ExperimentalFlags.enableSpeculativeDecoding = LlmRuntime.mtp
     val created = Engine(
         EngineConfig(
             modelPath = modelPath,


### PR DESCRIPTION
## Summary
- Add a Settings toggle for LiteRT-LM Gemma 4 multi-token prediction (MTP), labelled experimental and **off by default**.
- When enabled, set `ExperimentalFlags.enableSpeculativeDecoding` before engine creation (Android, desktop, and the Linux GPU worker).
- Persist the flag in the settings snapshot; older installs stay off. Reloading the model picks up a change (immediately if keep-alive is on).

## Test plan
- [x] `:shared:compileKotlinJvm` / `:shared:compileAndroidMain`
- [x] `:shared:jvmTest` (`AppViewModelTest`, `StringResourcesTest`, `LinuxGpuPolicyTest`)
- [ ] Open Settings → Model and confirm **Multi-token prediction (experimental)** is Off
- [ ] Turn it On, translate on GPU, confirm the engine reloads and decode is faster