### PR TITLE
fix: isolate LiteRT conversations

### DIFF
--- a/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/engine/NativeLlm.jvm.kt
+++ b/shared/src/jvmMain/kotlin/dev/nucleusframework/offlinetranslator/engine/NativeLlm.jvm.kt
@@ -21,7 +21,6 @@ import io.ktor.client.plugins.HttpTimeout
 internal actual class NativeLlm actual constructor() {
     private var engine: Engine? = null
     private var conversation: Conversation? = null
-    private var conversationSystem: String? = null
     private var worker: LinuxGpuWorkerProcess? = null
     private var loadedModelPath: String? = null
     private var loadedCacheDir: String? = null
@@ -117,8 +116,8 @@ internal actual class NativeLlm actual constructor() {
         onPartial: (String) -> Unit = {},
     ): String {
         val e = engine ?: error("Gemma 4 E2B n'est pas chargé.")
-        val conv = conversation?.takeIf { conversationSystem == systemInstruction }
-            ?: openConversation(e, systemInstruction)
+        // Fresh conversation every turn: reuse fills maxNumTokens and generate goes silent.
+        val conv = openConversation(e, systemInstruction)
         val acc = StringBuilder()
         val contents = Contents.of(
             buildList {
@@ -132,14 +131,16 @@ internal actual class NativeLlm actual constructor() {
                 acc.append(chunk.toString())
                 onPartial(acc.toString())
             }
+            return acc.toString()
         } catch (e: kotlinx.coroutines.CancellationException) {
             if (!linuxNativeTeardownUnsafe()) runCatching { conv.cancelProcess() }
             throw e
         } catch (t: Throwable) {
             if (!linuxNativeTeardownUnsafe()) runCatching { conv.cancelProcess() }
             throw t
+        } finally {
+            releaseConversation()
         }
-        return acc.toString()
     }
 
     actual fun close() {
@@ -179,14 +180,12 @@ internal actual class NativeLlm actual constructor() {
             ),
         )
         conversation = next
-        conversationSystem = systemInstruction
         return next
     }
 
     private fun releaseConversation() {
         val current = conversation
         conversation = null
-        conversationSystem = null
         // Official Kotlin samples keep the conversation open. nativeDeleteConversation
         // after a GPU turn SIGILL's in NVIDIA's shader compiler (libnvidia-gpucomp);
         // same "prints then dies" shape as LiteRT-LM#2570.


### PR DESCRIPTION
## Summary
- Start a new LiteRT conversation for each desktop generate, then release it, matching Android.
- Linux NVIDIA still skips `close()` (known SIGILL in `libnvidia-gpucomp`).

## Test plan
- [x] `./gradlew :shared:compileKotlinJvm`
- [x] `./gradlew :shared:jvmTest`
- [ ] Run a few translations in a row on desktop