### PR TITLE
chore: bump Nucleus to 2.4.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ multiplatformSettings = "1.3.0"
 kotlinx-datetime = "0.8.0"
 sqlDelight = "2.3.2"
 materialKolor = "5.0.0"
-nucleus = "2.4.3"
+nucleus = "2.4.4"
 # 0.15.0+ litertlm-jvm aborts the JVM on Windows CPU generate (0xC0000409 in
 # litertlm_jni.dll nativeGenerateContent / sendMessage). 0.14.0 is the last
 # good desktop JNI. https://github.com/google-ai-edge/LiteRT-LM/issues/3230


### PR DESCRIPTION
## Summary
- Bump Nucleus `2.4.3` → `2.4.4`.
- Picks up Tao fixes for Win11 CSD corners, Windows multi-monitor popup DPI, and the macOS press-and-hold accent picker.

## Test plan
- [x] `./gradlew :shared:compileKotlinJvm`
- [ ] Launch desktop and confirm the window chrome still looks correct