### PR TITLE
chore: bump Nucleus to 2.4.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ multiplatformSettings = "1.3.0"
 kotlinx-datetime = "0.8.0"
 sqlDelight = "2.3.2"
 materialKolor = "5.0.0"
-nucleus = "2.4.4"
+nucleus = "2.4.6"
 # 0.15.0+ litertlm-jvm aborts the JVM on Windows CPU generate (0xC0000409 in
 # litertlm_jni.dll nativeGenerateContent / sendMessage). 0.14.0 is the last
 # good desktop JNI. https://github.com/google-ai-edge/LiteRT-LM/issues/3230


### PR DESCRIPTION
Bumps `nucleus` from 2.4.4 to 2.4.6 in the version catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)